### PR TITLE
Do not throw when pushing to errored or closed channel

### DIFF
--- a/lib/src/channel.dart
+++ b/lib/src/channel.dart
@@ -281,13 +281,9 @@ class PhoenixChannel {
       _logger.finest(() => 'Sending out push ${pushEvent.ref}');
       pushEvent.send();
     } else {
-      if (_state == PhoenixChannelState.closed ||
-          _state == PhoenixChannelState.errored) {
-        throw ChannelClosedError('Can\'t push event on a $_state channel');
-      }
-
       _logger.finest(
           () => 'Buffering push ${pushEvent.ref} for later send ($_state)');
+      pushEvent.startTimeout();
       pushBuffer.add(pushEvent);
     }
 

--- a/test/channel_test.dart
+++ b/test/channel_test.dart
@@ -1,0 +1,38 @@
+import 'package:mockito/mockito.dart';
+import 'package:phoenix_socket/phoenix_socket.dart';
+import 'package:test/test.dart';
+
+import 'mocks.dart';
+
+void main() {
+  group('PhoenixChannel unit tests', () {
+    test(
+        'pushing an event into a channel with state PhoenixChannelState.closed does not throw',
+        () {
+      final mockSocket = MockPhoenixSocket();
+      when(mockSocket.defaultTimeout).thenReturn(Duration.zero);
+      when(mockSocket.isConnected).thenReturn(true);
+
+      final channel = PhoenixChannel.fromSocket(mockSocket, topic: 'test');
+      channel.join();
+      channel.close();
+
+      expect(channel.state, PhoenixChannelState.closed);
+      expect(() => channel.push('test-event', {}), returnsNormally);
+    });
+
+    test(
+        'pushing an event into a channel with state PhoenixChannelState.errored does not throw',
+        () {
+      final mockSocket = MockPhoenixSocket();
+      when(mockSocket.defaultTimeout).thenReturn(Duration.zero);
+      when(mockSocket.isConnected).thenReturn(false);
+
+      final channel = PhoenixChannel.fromSocket(mockSocket, topic: 'test');
+      channel.join();
+
+      expect(channel.state, PhoenixChannelState.errored);
+      expect(() => channel.push('test-event', {}), returnsNormally);
+    });
+  });
+}


### PR DESCRIPTION
Throwing in this scenario prevents the channel from recovering as throwing interrupts code execution and adding events to the `pushBuffer` to be retried on successful reconnect.

The reference JS implementation does not throw either and this PR brings the behavior closer to the reference implementation: https://github.com/phoenixframework/phoenix/blob/25e891f172045aa0391d30bfd794111235041159/assets/js/phoenix/channel.js#L183-L184