### PR TITLE
[DEV-11330] Double-check whether connection is possible after _buildMountPoint

### DIFF
--- a/test/mocks.dart
+++ b/test/mocks.dart
@@ -11,6 +11,7 @@ export 'mocks.mocks.dart';
     MockSpec<PhoenixSocket>(),
     MockSpec<WebSocketChannel>(),
     MockSpec<WebSocketSink>(),
+    MockSpec<PhoenixSocketOptions>(),
   ],
 )
 class MockTest extends Mock {

--- a/test/mocks.mocks.dart
+++ b/test/mocks.mocks.dart
@@ -3,17 +3,19 @@
 // Do not manually edit this file.
 
 // ignore_for_file: no_leading_underscores_for_library_prefixes
-import 'dart:async' as _i9;
+import 'dart:async' as _i10;
 
-import 'package:async/async.dart' as _i12;
+import 'package:async/async.dart' as _i13;
 import 'package:mockito/mockito.dart' as _i1;
-import 'package:mockito/src/dummies.dart' as _i8;
+import 'package:mockito/src/dummies.dart' as _i9;
 import 'package:phoenix_socket/src/channel.dart' as _i5;
-import 'package:phoenix_socket/src/events.dart' as _i10;
-import 'package:phoenix_socket/src/exceptions.dart' as _i11;
+import 'package:phoenix_socket/src/events.dart' as _i11;
+import 'package:phoenix_socket/src/exceptions.dart' as _i12;
 import 'package:phoenix_socket/src/message.dart' as _i3;
+import 'package:phoenix_socket/src/message_serializer.dart' as _i8;
 import 'package:phoenix_socket/src/push.dart' as _i4;
 import 'package:phoenix_socket/src/socket.dart' as _i2;
+import 'package:phoenix_socket/src/socket_options.dart' as _i14;
 import 'package:stream_channel/stream_channel.dart' as _i7;
 import 'package:web_socket_channel/web_socket_channel.dart' as _i6;
 
@@ -112,6 +114,17 @@ class _FakeStreamChannel_7<T> extends _i1.SmartFake
         );
 }
 
+class _FakeMessageSerializer_8 extends _i1.SmartFake
+    implements _i8.MessageSerializer {
+  _FakeMessageSerializer_8(
+    Object parent,
+    Invocation parentInvocation,
+  ) : super(
+          parent,
+          parentInvocation,
+        );
+}
+
 /// A class which mocks [PhoenixChannel].
 ///
 /// See the documentation for Mockito's code generation for more information.
@@ -139,11 +152,11 @@ class MockPhoenixChannel extends _i1.Mock implements _i5.PhoenixChannel {
   @override
   String get topic => (super.noSuchMethod(
         Invocation.getter(#topic),
-        returnValue: _i8.dummyValue<String>(
+        returnValue: _i9.dummyValue<String>(
           this,
           Invocation.getter(#topic),
         ),
-        returnValueForMissingStub: _i8.dummyValue<String>(
+        returnValueForMissingStub: _i9.dummyValue<String>(
           this,
           Invocation.getter(#topic),
         ),
@@ -157,20 +170,20 @@ class MockPhoenixChannel extends _i1.Mock implements _i5.PhoenixChannel {
       ) as List<_i4.Push>);
 
   @override
-  _i9.Stream<_i3.Message> get messages => (super.noSuchMethod(
+  _i10.Stream<_i3.Message> get messages => (super.noSuchMethod(
         Invocation.getter(#messages),
-        returnValue: _i9.Stream<_i3.Message>.empty(),
-        returnValueForMissingStub: _i9.Stream<_i3.Message>.empty(),
-      ) as _i9.Stream<_i3.Message>);
+        returnValue: _i10.Stream<_i3.Message>.empty(),
+        returnValueForMissingStub: _i10.Stream<_i3.Message>.empty(),
+      ) as _i10.Stream<_i3.Message>);
 
   @override
   String get joinRef => (super.noSuchMethod(
         Invocation.getter(#joinRef),
-        returnValue: _i8.dummyValue<String>(
+        returnValue: _i9.dummyValue<String>(
           this,
           Invocation.getter(#joinRef),
         ),
-        returnValueForMissingStub: _i8.dummyValue<String>(
+        returnValueForMissingStub: _i9.dummyValue<String>(
           this,
           Invocation.getter(#joinRef),
         ),
@@ -193,11 +206,11 @@ class MockPhoenixChannel extends _i1.Mock implements _i5.PhoenixChannel {
   @override
   String get loggerName => (super.noSuchMethod(
         Invocation.getter(#loggerName),
-        returnValue: _i8.dummyValue<String>(
+        returnValue: _i9.dummyValue<String>(
           this,
           Invocation.getter(#loggerName),
         ),
-        returnValueForMissingStub: _i8.dummyValue<String>(
+        returnValueForMissingStub: _i9.dummyValue<String>(
           this,
           Invocation.getter(#loggerName),
         ),
@@ -206,38 +219,39 @@ class MockPhoenixChannel extends _i1.Mock implements _i5.PhoenixChannel {
   @override
   String get reference => (super.noSuchMethod(
         Invocation.getter(#reference),
-        returnValue: _i8.dummyValue<String>(
+        returnValue: _i9.dummyValue<String>(
           this,
           Invocation.getter(#reference),
         ),
-        returnValueForMissingStub: _i8.dummyValue<String>(
+        returnValueForMissingStub: _i9.dummyValue<String>(
           this,
           Invocation.getter(#reference),
         ),
       ) as String);
 
   @override
-  _i9.Future<_i3.Message> onPushReply(_i10.PhoenixChannelEvent? replyEvent) =>
+  _i10.Future<_i3.Message> onPushReply(_i11.PhoenixChannelEvent? replyEvent) =>
       (super.noSuchMethod(
         Invocation.method(
           #onPushReply,
           [replyEvent],
         ),
-        returnValue: _i9.Future<_i3.Message>.value(_FakeMessage_1(
+        returnValue: _i10.Future<_i3.Message>.value(_FakeMessage_1(
           this,
           Invocation.method(
             #onPushReply,
             [replyEvent],
           ),
         )),
-        returnValueForMissingStub: _i9.Future<_i3.Message>.value(_FakeMessage_1(
+        returnValueForMissingStub:
+            _i10.Future<_i3.Message>.value(_FakeMessage_1(
           this,
           Invocation.method(
             #onPushReply,
             [replyEvent],
           ),
         )),
-      ) as _i9.Future<_i3.Message>);
+      ) as _i10.Future<_i3.Message>);
 
   @override
   void close() => super.noSuchMethod(
@@ -258,7 +272,7 @@ class MockPhoenixChannel extends _i1.Mock implements _i5.PhoenixChannel {
       );
 
   @override
-  void triggerError(_i11.PhoenixException? error) => super.noSuchMethod(
+  void triggerError(_i12.PhoenixException? error) => super.noSuchMethod(
         Invocation.method(
           #triggerError,
           [error],
@@ -354,7 +368,7 @@ class MockPhoenixChannel extends _i1.Mock implements _i5.PhoenixChannel {
 
   @override
   _i4.Push pushEvent(
-    _i10.PhoenixChannelEvent? event,
+    _i11.PhoenixChannelEvent? event,
     Map<String, dynamic>? payload, [
     Duration? newTimeout,
   ]) =>
@@ -414,46 +428,47 @@ class MockPhoenixSocket extends _i1.Mock implements _i2.PhoenixSocket {
       );
 
   @override
-  _i9.Stream<_i10.PhoenixSocketOpenEvent> get openStream => (super.noSuchMethod(
+  _i10.Stream<_i11.PhoenixSocketOpenEvent> get openStream =>
+      (super.noSuchMethod(
         Invocation.getter(#openStream),
-        returnValue: _i9.Stream<_i10.PhoenixSocketOpenEvent>.empty(),
+        returnValue: _i10.Stream<_i11.PhoenixSocketOpenEvent>.empty(),
         returnValueForMissingStub:
-            _i9.Stream<_i10.PhoenixSocketOpenEvent>.empty(),
-      ) as _i9.Stream<_i10.PhoenixSocketOpenEvent>);
+            _i10.Stream<_i11.PhoenixSocketOpenEvent>.empty(),
+      ) as _i10.Stream<_i11.PhoenixSocketOpenEvent>);
 
   @override
-  _i9.Stream<_i10.PhoenixSocketCloseEvent> get closeStream =>
+  _i10.Stream<_i11.PhoenixSocketCloseEvent> get closeStream =>
       (super.noSuchMethod(
         Invocation.getter(#closeStream),
-        returnValue: _i9.Stream<_i10.PhoenixSocketCloseEvent>.empty(),
+        returnValue: _i10.Stream<_i11.PhoenixSocketCloseEvent>.empty(),
         returnValueForMissingStub:
-            _i9.Stream<_i10.PhoenixSocketCloseEvent>.empty(),
-      ) as _i9.Stream<_i10.PhoenixSocketCloseEvent>);
+            _i10.Stream<_i11.PhoenixSocketCloseEvent>.empty(),
+      ) as _i10.Stream<_i11.PhoenixSocketCloseEvent>);
 
   @override
-  _i9.Stream<_i10.PhoenixSocketErrorEvent> get errorStream =>
+  _i10.Stream<_i11.PhoenixSocketErrorEvent> get errorStream =>
       (super.noSuchMethod(
         Invocation.getter(#errorStream),
-        returnValue: _i9.Stream<_i10.PhoenixSocketErrorEvent>.empty(),
+        returnValue: _i10.Stream<_i11.PhoenixSocketErrorEvent>.empty(),
         returnValueForMissingStub:
-            _i9.Stream<_i10.PhoenixSocketErrorEvent>.empty(),
-      ) as _i9.Stream<_i10.PhoenixSocketErrorEvent>);
+            _i10.Stream<_i11.PhoenixSocketErrorEvent>.empty(),
+      ) as _i10.Stream<_i11.PhoenixSocketErrorEvent>);
 
   @override
-  _i9.Stream<_i3.Message> get messageStream => (super.noSuchMethod(
+  _i10.Stream<_i3.Message> get messageStream => (super.noSuchMethod(
         Invocation.getter(#messageStream),
-        returnValue: _i9.Stream<_i3.Message>.empty(),
-        returnValueForMissingStub: _i9.Stream<_i3.Message>.empty(),
-      ) as _i9.Stream<_i3.Message>);
+        returnValue: _i10.Stream<_i3.Message>.empty(),
+        returnValueForMissingStub: _i10.Stream<_i3.Message>.empty(),
+      ) as _i10.Stream<_i3.Message>);
 
   @override
   String get nextRef => (super.noSuchMethod(
         Invocation.getter(#nextRef),
-        returnValue: _i8.dummyValue<String>(
+        returnValue: _i9.dummyValue<String>(
           this,
           Invocation.getter(#nextRef),
         ),
-        returnValueForMissingStub: _i8.dummyValue<String>(
+        returnValueForMissingStub: _i9.dummyValue<String>(
           this,
           Invocation.getter(#nextRef),
         ),
@@ -475,11 +490,11 @@ class MockPhoenixSocket extends _i1.Mock implements _i2.PhoenixSocket {
   @override
   String get endpoint => (super.noSuchMethod(
         Invocation.getter(#endpoint),
-        returnValue: _i8.dummyValue<String>(
+        returnValue: _i9.dummyValue<String>(
           this,
           Invocation.getter(#endpoint),
         ),
-        returnValueForMissingStub: _i8.dummyValue<String>(
+        returnValueForMissingStub: _i9.dummyValue<String>(
           this,
           Invocation.getter(#endpoint),
         ),
@@ -506,24 +521,24 @@ class MockPhoenixSocket extends _i1.Mock implements _i2.PhoenixSocket {
       ) as bool);
 
   @override
-  _i9.Stream<_i3.Message> streamForTopic(String? topic) => (super.noSuchMethod(
+  _i10.Stream<_i3.Message> streamForTopic(String? topic) => (super.noSuchMethod(
         Invocation.method(
           #streamForTopic,
           [topic],
         ),
-        returnValue: _i9.Stream<_i3.Message>.empty(),
-        returnValueForMissingStub: _i9.Stream<_i3.Message>.empty(),
-      ) as _i9.Stream<_i3.Message>);
+        returnValue: _i10.Stream<_i3.Message>.empty(),
+        returnValueForMissingStub: _i10.Stream<_i3.Message>.empty(),
+      ) as _i10.Stream<_i3.Message>);
 
   @override
-  _i9.Future<_i2.PhoenixSocket?> connect() => (super.noSuchMethod(
+  _i10.Future<_i2.PhoenixSocket?> connect() => (super.noSuchMethod(
         Invocation.method(
           #connect,
           [],
         ),
-        returnValue: _i9.Future<_i2.PhoenixSocket?>.value(),
-        returnValueForMissingStub: _i9.Future<_i2.PhoenixSocket?>.value(),
-      ) as _i9.Future<_i2.PhoenixSocket?>);
+        returnValue: _i10.Future<_i2.PhoenixSocket?>.value(),
+        returnValueForMissingStub: _i10.Future<_i2.PhoenixSocket?>.value(),
+      ) as _i10.Future<_i2.PhoenixSocket?>);
 
   @override
   void close([
@@ -553,50 +568,52 @@ class MockPhoenixSocket extends _i1.Mock implements _i2.PhoenixSocket {
       );
 
   @override
-  _i9.Future<_i3.Message> waitForMessage(_i3.Message? message) =>
+  _i10.Future<_i3.Message> waitForMessage(_i3.Message? message) =>
       (super.noSuchMethod(
         Invocation.method(
           #waitForMessage,
           [message],
         ),
-        returnValue: _i9.Future<_i3.Message>.value(_FakeMessage_1(
+        returnValue: _i10.Future<_i3.Message>.value(_FakeMessage_1(
           this,
           Invocation.method(
             #waitForMessage,
             [message],
           ),
         )),
-        returnValueForMissingStub: _i9.Future<_i3.Message>.value(_FakeMessage_1(
+        returnValueForMissingStub:
+            _i10.Future<_i3.Message>.value(_FakeMessage_1(
           this,
           Invocation.method(
             #waitForMessage,
             [message],
           ),
         )),
-      ) as _i9.Future<_i3.Message>);
+      ) as _i10.Future<_i3.Message>);
 
   @override
-  _i9.Future<_i3.Message> sendMessage(_i3.Message? message) =>
+  _i10.Future<_i3.Message> sendMessage(_i3.Message? message) =>
       (super.noSuchMethod(
         Invocation.method(
           #sendMessage,
           [message],
         ),
-        returnValue: _i9.Future<_i3.Message>.value(_FakeMessage_1(
+        returnValue: _i10.Future<_i3.Message>.value(_FakeMessage_1(
           this,
           Invocation.method(
             #sendMessage,
             [message],
           ),
         )),
-        returnValueForMissingStub: _i9.Future<_i3.Message>.value(_FakeMessage_1(
+        returnValueForMissingStub:
+            _i10.Future<_i3.Message>.value(_FakeMessage_1(
           this,
           Invocation.method(
             #sendMessage,
             [message],
           ),
         )),
-      ) as _i9.Future<_i3.Message>);
+      ) as _i10.Future<_i3.Message>);
 
   @override
   _i5.PhoenixChannel addChannel({
@@ -655,18 +672,18 @@ class MockPhoenixSocket extends _i1.Mock implements _i2.PhoenixSocket {
 /// See the documentation for Mockito's code generation for more information.
 class MockWebSocketChannel extends _i1.Mock implements _i6.WebSocketChannel {
   @override
-  _i9.Future<void> get ready => (super.noSuchMethod(
+  _i10.Future<void> get ready => (super.noSuchMethod(
         Invocation.getter(#ready),
-        returnValue: _i9.Future<void>.value(),
-        returnValueForMissingStub: _i9.Future<void>.value(),
-      ) as _i9.Future<void>);
+        returnValue: _i10.Future<void>.value(),
+        returnValueForMissingStub: _i10.Future<void>.value(),
+      ) as _i10.Future<void>);
 
   @override
-  _i9.Stream<dynamic> get stream => (super.noSuchMethod(
+  _i10.Stream<dynamic> get stream => (super.noSuchMethod(
         Invocation.getter(#stream),
-        returnValue: _i9.Stream<dynamic>.empty(),
-        returnValueForMissingStub: _i9.Stream<dynamic>.empty(),
-      ) as _i9.Stream<dynamic>);
+        returnValue: _i10.Stream<dynamic>.empty(),
+        returnValueForMissingStub: _i10.Stream<dynamic>.empty(),
+      ) as _i10.Stream<dynamic>);
 
   @override
   _i6.WebSocketSink get sink => (super.noSuchMethod(
@@ -716,7 +733,7 @@ class MockWebSocketChannel extends _i1.Mock implements _i6.WebSocketChannel {
 
   @override
   _i7.StreamChannel<dynamic> transformStream(
-          _i9.StreamTransformer<dynamic, dynamic>? transformer) =>
+          _i10.StreamTransformer<dynamic, dynamic>? transformer) =>
       (super.noSuchMethod(
         Invocation.method(
           #transformStream,
@@ -740,7 +757,7 @@ class MockWebSocketChannel extends _i1.Mock implements _i6.WebSocketChannel {
 
   @override
   _i7.StreamChannel<dynamic> transformSink(
-          _i12.StreamSinkTransformer<dynamic, dynamic>? transformer) =>
+          _i13.StreamSinkTransformer<dynamic, dynamic>? transformer) =>
       (super.noSuchMethod(
         Invocation.method(
           #transformSink,
@@ -764,7 +781,7 @@ class MockWebSocketChannel extends _i1.Mock implements _i6.WebSocketChannel {
 
   @override
   _i7.StreamChannel<dynamic> changeStream(
-          _i9.Stream<dynamic> Function(_i9.Stream<dynamic>)? change) =>
+          _i10.Stream<dynamic> Function(_i10.Stream<dynamic>)? change) =>
       (super.noSuchMethod(
         Invocation.method(
           #changeStream,
@@ -788,7 +805,8 @@ class MockWebSocketChannel extends _i1.Mock implements _i6.WebSocketChannel {
 
   @override
   _i7.StreamChannel<dynamic> changeSink(
-          _i9.StreamSink<dynamic> Function(_i9.StreamSink<dynamic>)? change) =>
+          _i10.StreamSink<dynamic> Function(_i10.StreamSink<dynamic>)?
+              change) =>
       (super.noSuchMethod(
         Invocation.method(
           #changeSink,
@@ -838,14 +856,14 @@ class MockWebSocketChannel extends _i1.Mock implements _i6.WebSocketChannel {
 /// See the documentation for Mockito's code generation for more information.
 class MockWebSocketSink extends _i1.Mock implements _i6.WebSocketSink {
   @override
-  _i9.Future<dynamic> get done => (super.noSuchMethod(
+  _i10.Future<dynamic> get done => (super.noSuchMethod(
         Invocation.getter(#done),
-        returnValue: _i9.Future<dynamic>.value(),
-        returnValueForMissingStub: _i9.Future<dynamic>.value(),
-      ) as _i9.Future<dynamic>);
+        returnValue: _i10.Future<dynamic>.value(),
+        returnValueForMissingStub: _i10.Future<dynamic>.value(),
+      ) as _i10.Future<dynamic>);
 
   @override
-  _i9.Future<dynamic> close([
+  _i10.Future<dynamic> close([
     int? closeCode,
     String? closeReason,
   ]) =>
@@ -857,9 +875,9 @@ class MockWebSocketSink extends _i1.Mock implements _i6.WebSocketSink {
             closeReason,
           ],
         ),
-        returnValue: _i9.Future<dynamic>.value(),
-        returnValueForMissingStub: _i9.Future<dynamic>.value(),
-      ) as _i9.Future<dynamic>);
+        returnValue: _i10.Future<dynamic>.value(),
+        returnValueForMissingStub: _i10.Future<dynamic>.value(),
+      ) as _i10.Future<dynamic>);
 
   @override
   void add(dynamic data) => super.noSuchMethod(
@@ -887,13 +905,76 @@ class MockWebSocketSink extends _i1.Mock implements _i6.WebSocketSink {
       );
 
   @override
-  _i9.Future<dynamic> addStream(_i9.Stream<dynamic>? stream) =>
+  _i10.Future<dynamic> addStream(_i10.Stream<dynamic>? stream) =>
       (super.noSuchMethod(
         Invocation.method(
           #addStream,
           [stream],
         ),
-        returnValue: _i9.Future<dynamic>.value(),
-        returnValueForMissingStub: _i9.Future<dynamic>.value(),
-      ) as _i9.Future<dynamic>);
+        returnValue: _i10.Future<dynamic>.value(),
+        returnValueForMissingStub: _i10.Future<dynamic>.value(),
+      ) as _i10.Future<dynamic>);
+}
+
+/// A class which mocks [PhoenixSocketOptions].
+///
+/// See the documentation for Mockito's code generation for more information.
+class MockPhoenixSocketOptions extends _i1.Mock
+    implements _i14.PhoenixSocketOptions {
+  @override
+  _i8.MessageSerializer get serializer => (super.noSuchMethod(
+        Invocation.getter(#serializer),
+        returnValue: _FakeMessageSerializer_8(
+          this,
+          Invocation.getter(#serializer),
+        ),
+        returnValueForMissingStub: _FakeMessageSerializer_8(
+          this,
+          Invocation.getter(#serializer),
+        ),
+      ) as _i8.MessageSerializer);
+
+  @override
+  List<Duration> get reconnectDelays => (super.noSuchMethod(
+        Invocation.getter(#reconnectDelays),
+        returnValue: <Duration>[],
+        returnValueForMissingStub: <Duration>[],
+      ) as List<Duration>);
+
+  @override
+  Duration get timeout => (super.noSuchMethod(
+        Invocation.getter(#timeout),
+        returnValue: _FakeDuration_3(
+          this,
+          Invocation.getter(#timeout),
+        ),
+        returnValueForMissingStub: _FakeDuration_3(
+          this,
+          Invocation.getter(#timeout),
+        ),
+      ) as Duration);
+
+  @override
+  Duration get heartbeat => (super.noSuchMethod(
+        Invocation.getter(#heartbeat),
+        returnValue: _FakeDuration_3(
+          this,
+          Invocation.getter(#heartbeat),
+        ),
+        returnValueForMissingStub: _FakeDuration_3(
+          this,
+          Invocation.getter(#heartbeat),
+        ),
+      ) as Duration);
+
+  @override
+  _i10.Future<Map<String, String>> getParams() => (super.noSuchMethod(
+        Invocation.method(
+          #getParams,
+          [],
+        ),
+        returnValue: _i10.Future<Map<String, String>>.value(<String, String>{}),
+        returnValueForMissingStub:
+            _i10.Future<Map<String, String>>.value(<String, String>{}),
+      ) as _i10.Future<Map<String, String>>);
 }

--- a/test/socket_test.dart
+++ b/test/socket_test.dart
@@ -5,6 +5,7 @@ import 'package:mockito/mockito.dart';
 import 'package:phoenix_socket/phoenix_socket.dart';
 import 'package:rxdart/rxdart.dart';
 import 'package:test/test.dart';
+import 'package:web_socket_channel/web_socket_channel.dart';
 
 import 'mocks.dart';
 
@@ -49,5 +50,65 @@ void main() {
 
     // Expect the first two unexpected failures to be retried
     verify(sink.add(any)).called(3);
+  });
+
+  test('socket connect does not create new socket if one is already connected',
+      () async {
+    final optionsCompleter = Completer<Map<String, String>>();
+    final mockPhoenixSocketOptions = MockPhoenixSocketOptions();
+    when(mockPhoenixSocketOptions.getParams())
+        .thenAnswer((_) => optionsCompleter.future);
+    when(mockPhoenixSocketOptions.heartbeat).thenReturn(Duration(days: 1));
+
+    final sentRefs = <String>[];
+    when(mockPhoenixSocketOptions.serializer).thenReturn(MessageSerializer(
+      encoder: (object) {
+        if (object is List) {
+          final message = Message.fromJson(object);
+          sentRefs.add(message.ref!);
+          return message.ref!;
+        }
+        return 'ignored';
+      },
+      decoder: (ref) => Message.heartbeat(ref).encode(),
+    ));
+
+    int factoryCalls = 0;
+    WebSocketChannel stubWebSocketChannelFactory(Uri uri) {
+      ++factoryCalls;
+      final mockWebSocketChannel = MockWebSocketChannel();
+      when(mockWebSocketChannel.stream).thenAnswer((_) => NeverStream());
+      when(mockWebSocketChannel.ready)
+          .thenAnswer((_) => Future.sync(() => null));
+      when(mockWebSocketChannel.sink).thenReturn(MockWebSocketSink());
+      return mockWebSocketChannel;
+    }
+
+    final phoenixSocket = PhoenixSocket(
+      'ws://endpoint',
+      webSocketChannelFactory: stubWebSocketChannelFactory,
+      socketOptions: mockPhoenixSocketOptions,
+    );
+
+    // Connect to the socket
+    final connectFutures = [
+      phoenixSocket.connect(),
+      phoenixSocket.connect(),
+      phoenixSocket.connect(),
+    ];
+
+    expect(factoryCalls, 0);
+
+    optionsCompleter.complete({'token': 'fakeUserToken'});
+
+    await Future.delayed(Duration.zero);
+
+    for (final ref in sentRefs) {
+      phoenixSocket.onSocketDataCallback(ref);
+    }
+
+    await Future.wait(connectFutures);
+
+    expect(factoryCalls, 1);
   });
 }


### PR DESCRIPTION
See https://linear.app/superlist/issue/DEV-11330/investigate-why-mac-app-opens-two-websocket-connections-in-parallel#comment-aa629c7d for clarification on why this change is made.