### PR TITLE
[DEV-11330] Second attempt to fix issue with multiple phoenix socket connections

### DIFF
--- a/example/more_examples/reactive/client/pubspec.yaml
+++ b/example/more_examples/reactive/client/pubspec.yaml
@@ -25,7 +25,7 @@ dependencies:
     sdk: flutter
     
   phoenix_socket:
-    path: ../../../
+    path: ../../../../
 
   # The following adds the Cupertino Icons font to your application.
   # Use with the CupertinoIcons class for iOS style icons.

--- a/lib/src/socket.dart
+++ b/lib/src/socket.dart
@@ -327,7 +327,7 @@ class PhoenixSocket {
 
   /// Send a channel on the socket.
   ///
-  /// Used internal to send prepared message. If you need to send
+  /// Used internally to send prepared message. If you need to send
   /// a message on a channel, you would usually use [PhoenixChannel.push]
   /// instead.
   Future<Message> sendMessage(Message message) {

--- a/test/socket_test.dart
+++ b/test/socket_test.dart
@@ -15,6 +15,7 @@ void main() {
     final websocket = MockWebSocketChannel();
     final phoenixSocket = PhoenixSocket(
       'endpoint',
+      socketOptions: PhoenixSocketOptions(params: {'token': 'token'}),
       webSocketChannelFactory: (_) => websocket,
     );
     int invocations = 0;


### PR DESCRIPTION
Second attempt to fix issue where a client creates multiple phoenix socket connections:
* Change the socket state to `connecting` before the async call to build the mount point
* Removed the double-checking of socket state after building the mount point
* Await for the socket to be ready after its creation and change then the socket state to `connected`

Aside from the change, removed the old implementation of `connect()` where it wrapped `_connect()` with `runZonedGuarded()`, since it was swallowing exceptions and just made the code more complicated to read.

Other minor improvements:
* Formatted `lib/src/socket.dart`
* Fixed typos in comments
* fixed `example/more_examples/reactive/client/pubspec.yaml` to clear analyzer errors.

There were way more changes that we should do in the `PhoenixSocket` class for things that seem to be incorrect, but I refrained from doing it in this PR, both my the and reviewers sanity.